### PR TITLE
fix: Autolink iOS platform

### DIFF
--- a/RNTextSize.podspec
+++ b/RNTextSize.podspec
@@ -1,5 +1,5 @@
 require 'json'
-package = JSON.parse(File.read('../package.json'))
+package = JSON.parse(File.read('./package.json'))
 
 Pod::Spec.new do |s|
   s.name         = 'RNTextSize'
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author       = package['author']
   s.platform     = :ios, '9.0'
   s.source       = { :git => package['repository'], :tag => "v#{s.version}" }
-  s.source_files = '*.{h,m}'
+  s.source_files = 'ios/*.{h,m}'
   s.requires_arc = true
 
   s.dependency 'React'

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
   },
   "peerDependencies": {
     "react-native": ">=0.59.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Solution to the autolink error in iOS, this problem occurred when creating a build or starting the application in development mode and this process did not link this library.